### PR TITLE
New intro text suggestion that fixes also a typo on tutorials page

### DIFF
--- a/_pages/tutorials/tutorials.html
+++ b/_pages/tutorials/tutorials.html
@@ -8,7 +8,7 @@ sitemap: false
 ---
 
 <p class="lead mb-4">
-  Hier bieten wir euch einen einfachen Einstieg Vue.js!
+  Hier bieten wir euch hilfreiche Tutorials zu Vue.js die euch den Einstieg in das beliebte JavaScript Framework erleichtern!
 </p>
 
 <div class="list-group mb-5">


### PR DESCRIPTION
Eigentlich wollte ich nur den Typo fixen "einfachen Einstieg Vue.js!" -> "einfachen Einstieg in Vue.js!" aber ich finde das der ganze Satz etwas aufpoliert werden sollte :)